### PR TITLE
Avoid lazy session collection access in async processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,63 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>aifuzzy</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>aifuzzy</name>
+    <description>Service that generates dynamic HTTP requests via LLM and captures statistics</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/aifuzzy/AiFuzzyApplication.java
+++ b/src/main/java/com/example/aifuzzy/AiFuzzyApplication.java
@@ -1,0 +1,14 @@
+package com.example.aifuzzy;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@SpringBootApplication
+@EnableAsync
+public class AiFuzzyApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AiFuzzyApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/aifuzzy/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/aifuzzy/controller/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.example.aifuzzy.controller;
+
+import com.example.aifuzzy.exception.ResourceNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleResourceNotFound(ResourceNotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of("message", exception.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException exception) {
+        return ResponseEntity.badRequest()
+                .body(Map.of("message", exception.getMessage()));
+    }
+}

--- a/src/main/java/com/example/aifuzzy/controller/TestSessionController.java
+++ b/src/main/java/com/example/aifuzzy/controller/TestSessionController.java
@@ -1,0 +1,51 @@
+package com.example.aifuzzy.controller;
+
+import com.example.aifuzzy.dto.RequestResultDto;
+import com.example.aifuzzy.dto.TestSessionCreateRequestDto;
+import com.example.aifuzzy.dto.TestSessionResponseDto;
+import com.example.aifuzzy.dto.TestSessionSummaryDto;
+import com.example.aifuzzy.service.TestSessionService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/test-sessions")
+public class TestSessionController {
+
+    private final TestSessionService testSessionService;
+
+    public TestSessionController(TestSessionService testSessionService) {
+        this.testSessionService = testSessionService;
+    }
+
+    @PostMapping
+    public ResponseEntity<TestSessionResponseDto> createSession(@Valid @RequestBody TestSessionCreateRequestDto requestDto) {
+        TestSessionResponseDto responseDto = testSessionService.createSession(requestDto);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(responseDto.sessionId())
+                .toUri();
+        return ResponseEntity.accepted().location(location).body(responseDto);
+    }
+
+    @GetMapping("/{sessionId}")
+    public TestSessionSummaryDto getSessionSummary(@PathVariable UUID sessionId) {
+        return testSessionService.getSessionSummary(sessionId);
+    }
+
+    @GetMapping("/{sessionId}/results")
+    public List<RequestResultDto> getSessionResults(@PathVariable UUID sessionId) {
+        return testSessionService.getSessionResults(sessionId);
+    }
+}

--- a/src/main/java/com/example/aifuzzy/domain/GeneratedRequestEntity.java
+++ b/src/main/java/com/example/aifuzzy/domain/GeneratedRequestEntity.java
@@ -1,0 +1,125 @@
+package com.example.aifuzzy.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "generated_requests")
+public class GeneratedRequestEntity {
+
+    @Id
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private TestSessionEntity session;
+
+    @Column(name = "http_method", nullable = false)
+    private String httpMethod;
+
+    @Column(name = "path", nullable = false)
+    private String path;
+
+    @Lob
+    @Column(name = "query_parameters")
+    private String queryParameters;
+
+    @Lob
+    @Column(name = "headers")
+    private String headers;
+
+    @Lob
+    @Column(name = "body")
+    private String body;
+
+    @Lob
+    @Column(name = "description")
+    private String description;
+
+    @OneToMany(mappedBy = "generatedRequest", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<RequestExecutionEntity> executions = new ArrayList<>();
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public TestSessionEntity getSession() {
+        return session;
+    }
+
+    public void setSession(TestSessionEntity session) {
+        this.session = session;
+    }
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public void setHttpMethod(String httpMethod) {
+        this.httpMethod = httpMethod;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getQueryParameters() {
+        return queryParameters;
+    }
+
+    public void setQueryParameters(String queryParameters) {
+        this.queryParameters = queryParameters;
+    }
+
+    public String getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(String headers) {
+        this.headers = headers;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<RequestExecutionEntity> getExecutions() {
+        return executions;
+    }
+
+    public void setExecutions(List<RequestExecutionEntity> executions) {
+        this.executions = executions;
+    }
+}

--- a/src/main/java/com/example/aifuzzy/domain/RequestExecutionEntity.java
+++ b/src/main/java/com/example/aifuzzy/domain/RequestExecutionEntity.java
@@ -1,0 +1,121 @@
+package com.example.aifuzzy.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "request_executions")
+public class RequestExecutionEntity {
+
+    @Id
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "generated_request_id", nullable = false)
+    private GeneratedRequestEntity generatedRequest;
+
+    @Column(name = "final_url", nullable = false)
+    private String finalUrl;
+
+    @Column(name = "executed_at", nullable = false)
+    private Instant executedAt;
+
+    @Column(name = "status_code")
+    private Integer statusCode;
+
+    @Column(name = "latency_millis")
+    private Long latencyMillis;
+
+    @Lob
+    @Column(name = "response_body")
+    private String responseBody;
+
+    @Lob
+    @Column(name = "response_headers")
+    private String responseHeaders;
+
+    @Lob
+    @Column(name = "error_message")
+    private String errorMessage;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public GeneratedRequestEntity getGeneratedRequest() {
+        return generatedRequest;
+    }
+
+    public void setGeneratedRequest(GeneratedRequestEntity generatedRequest) {
+        this.generatedRequest = generatedRequest;
+    }
+
+    public String getFinalUrl() {
+        return finalUrl;
+    }
+
+    public void setFinalUrl(String finalUrl) {
+        this.finalUrl = finalUrl;
+    }
+
+    public Instant getExecutedAt() {
+        return executedAt;
+    }
+
+    public void setExecutedAt(Instant executedAt) {
+        this.executedAt = executedAt;
+    }
+
+    public Integer getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(Integer statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public Long getLatencyMillis() {
+        return latencyMillis;
+    }
+
+    public void setLatencyMillis(Long latencyMillis) {
+        this.latencyMillis = latencyMillis;
+    }
+
+    public String getResponseBody() {
+        return responseBody;
+    }
+
+    public void setResponseBody(String responseBody) {
+        this.responseBody = responseBody;
+    }
+
+    public String getResponseHeaders() {
+        return responseHeaders;
+    }
+
+    public void setResponseHeaders(String responseHeaders) {
+        this.responseHeaders = responseHeaders;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/com/example/aifuzzy/domain/SessionStatus.java
+++ b/src/main/java/com/example/aifuzzy/domain/SessionStatus.java
@@ -1,0 +1,8 @@
+package com.example.aifuzzy.domain;
+
+public enum SessionStatus {
+    PENDING,
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/example/aifuzzy/domain/TestSessionEntity.java
+++ b/src/main/java/com/example/aifuzzy/domain/TestSessionEntity.java
@@ -1,0 +1,123 @@
+package com.example.aifuzzy.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "test_sessions")
+public class TestSessionEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(name = "base_url", nullable = false)
+    private String baseUrl;
+
+    @Lob
+    @Column(name = "specification", nullable = false)
+    private String specification;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private SessionStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @Column(name = "failure_message")
+    private String failureMessage;
+
+    @Column(name = "max_requests")
+    private Integer maxRequests;
+
+    @OneToMany(mappedBy = "session", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<GeneratedRequestEntity> generatedRequests = new ArrayList<>();
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getSpecification() {
+        return specification;
+    }
+
+    public void setSpecification(String specification) {
+        this.specification = specification;
+    }
+
+    public SessionStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(SessionStatus status) {
+        this.status = status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public String getFailureMessage() {
+        return failureMessage;
+    }
+
+    public void setFailureMessage(String failureMessage) {
+        this.failureMessage = failureMessage;
+    }
+
+    public Integer getMaxRequests() {
+        return maxRequests;
+    }
+
+    public void setMaxRequests(Integer maxRequests) {
+        this.maxRequests = maxRequests;
+    }
+
+    public List<GeneratedRequestEntity> getGeneratedRequests() {
+        return generatedRequests;
+    }
+
+    public void setGeneratedRequests(List<GeneratedRequestEntity> generatedRequests) {
+        this.generatedRequests = generatedRequests;
+    }
+}

--- a/src/main/java/com/example/aifuzzy/dto/RequestExecutionDto.java
+++ b/src/main/java/com/example/aifuzzy/dto/RequestExecutionDto.java
@@ -1,0 +1,17 @@
+package com.example.aifuzzy.dto;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+public record RequestExecutionDto(
+        UUID executionId,
+        String finalUrl,
+        Instant executedAt,
+        Integer statusCode,
+        Long latencyMillis,
+        Map<String, String> responseHeaders,
+        String responseBody,
+        String errorMessage
+) {
+}

--- a/src/main/java/com/example/aifuzzy/dto/RequestResultDto.java
+++ b/src/main/java/com/example/aifuzzy/dto/RequestResultDto.java
@@ -1,0 +1,17 @@
+package com.example.aifuzzy.dto;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record RequestResultDto(
+        UUID requestId,
+        String method,
+        String path,
+        Map<String, Object> queryParameters,
+        Map<String, String> headers,
+        String body,
+        String description,
+        List<RequestExecutionDto> executions
+) {
+}

--- a/src/main/java/com/example/aifuzzy/dto/TestSessionCreateRequestDto.java
+++ b/src/main/java/com/example/aifuzzy/dto/TestSessionCreateRequestDto.java
@@ -1,0 +1,40 @@
+package com.example.aifuzzy.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public class TestSessionCreateRequestDto {
+
+    @NotBlank
+    private String baseUrl;
+
+    @NotBlank
+    private String specification;
+
+    @Min(1)
+    private Integer maxRequests;
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getSpecification() {
+        return specification;
+    }
+
+    public void setSpecification(String specification) {
+        this.specification = specification;
+    }
+
+    public Integer getMaxRequests() {
+        return maxRequests;
+    }
+
+    public void setMaxRequests(Integer maxRequests) {
+        this.maxRequests = maxRequests;
+    }
+}

--- a/src/main/java/com/example/aifuzzy/dto/TestSessionResponseDto.java
+++ b/src/main/java/com/example/aifuzzy/dto/TestSessionResponseDto.java
@@ -1,0 +1,8 @@
+package com.example.aifuzzy.dto;
+
+import com.example.aifuzzy.domain.SessionStatus;
+
+import java.util.UUID;
+
+public record TestSessionResponseDto(UUID sessionId, SessionStatus status) {
+}

--- a/src/main/java/com/example/aifuzzy/dto/TestSessionSummaryDto.java
+++ b/src/main/java/com/example/aifuzzy/dto/TestSessionSummaryDto.java
@@ -1,0 +1,23 @@
+package com.example.aifuzzy.dto;
+
+import com.example.aifuzzy.domain.SessionStatus;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+public record TestSessionSummaryDto(
+        UUID sessionId,
+        SessionStatus status,
+        int generatedRequests,
+        int executedRequests,
+        int successCount,
+        int failureCount,
+        double successRate,
+        Long averageLatencyMillis,
+        Map<Integer, Long> statusCodeHistogram,
+        Instant createdAt,
+        Instant updatedAt,
+        String failureMessage
+) {
+}

--- a/src/main/java/com/example/aifuzzy/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/example/aifuzzy/exception/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.aifuzzy.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/aifuzzy/http/HttpExecutionResult.java
+++ b/src/main/java/com/example/aifuzzy/http/HttpExecutionResult.java
@@ -1,0 +1,14 @@
+package com.example.aifuzzy.http;
+
+import java.net.URI;
+import java.util.Map;
+
+public record HttpExecutionResult(
+        URI finalUrl,
+        Integer statusCode,
+        String responseBody,
+        Map<String, String> responseHeaders,
+        Long latencyMillis,
+        String errorMessage
+) {
+}

--- a/src/main/java/com/example/aifuzzy/http/HttpRequestExecutor.java
+++ b/src/main/java/com/example/aifuzzy/http/HttpRequestExecutor.java
@@ -1,0 +1,10 @@
+package com.example.aifuzzy.http;
+
+import com.example.aifuzzy.llm.GeneratedHttpRequest;
+
+import java.net.URI;
+
+public interface HttpRequestExecutor {
+
+    HttpExecutionResult execute(URI baseUri, GeneratedHttpRequest request);
+}

--- a/src/main/java/com/example/aifuzzy/http/WebClientHttpRequestExecutor.java
+++ b/src/main/java/com/example/aifuzzy/http/WebClientHttpRequestExecutor.java
@@ -1,0 +1,153 @@
+package com.example.aifuzzy.http;
+
+import com.example.aifuzzy.llm.GeneratedHttpRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@Component
+public class WebClientHttpRequestExecutor implements HttpRequestExecutor {
+
+    private final WebClient webClient;
+
+    public WebClientHttpRequestExecutor(WebClient.Builder builder) {
+        this.webClient = builder.build();
+    }
+
+    @Override
+    public HttpExecutionResult execute(URI baseUri, GeneratedHttpRequest request) {
+        URI targetUri = buildUri(baseUri, request);
+        HttpHeaders headers = new HttpHeaders();
+        if (request.headers() != null) {
+            request.headers().forEach(headers::add);
+        }
+        boolean hasBody = request.body() != null && allowsBody(request.method());
+        if (hasBody && headers.getContentType() == null) {
+            headers.setContentType(MediaType.APPLICATION_JSON);
+        }
+
+        Instant startedAt = Instant.now();
+        try {
+            WebClient.RequestBodySpec bodySpec = webClient.method(request.method())
+                    .uri(targetUri)
+                    .headers(h -> h.addAll(headers));
+
+            WebClient.RequestHeadersSpec<?> headersSpec = bodySpec;
+            if (hasBody) {
+                headersSpec = bodySpec.bodyValue(request.body());
+            }
+
+            ResponseEntity<String> responseEntity = headersSpec.exchangeToMono(response -> response.toEntity(String.class))
+                    .block();
+
+            Instant finishedAt = Instant.now();
+            long latency = Duration.between(startedAt, finishedAt).toMillis();
+            Map<String, String> responseHeaders = flattenHeaders(responseEntity.getHeaders());
+            return new HttpExecutionResult(
+                    targetUri,
+                    responseEntity.getStatusCode().value(),
+                    responseEntity.getBody(),
+                    responseHeaders,
+                    latency,
+                    null
+            );
+        } catch (WebClientResponseException exception) {
+            Instant finishedAt = Instant.now();
+            long latency = Duration.between(startedAt, finishedAt).toMillis();
+            Map<String, String> responseHeaders = flattenHeaders(exception.getHeaders());
+            return new HttpExecutionResult(
+                    targetUri,
+                    exception.getRawStatusCode(),
+                    exception.getResponseBodyAsString(),
+                    responseHeaders,
+                    latency,
+                    exception.getMessage()
+            );
+        } catch (WebClientRequestException exception) {
+            Instant finishedAt = Instant.now();
+            long latency = Duration.between(startedAt, finishedAt).toMillis();
+            return new HttpExecutionResult(
+                    targetUri,
+                    null,
+                    null,
+                    Map.of(),
+                    latency,
+                    exception.getMessage()
+            );
+        }
+    }
+
+    private URI buildUri(URI baseUri, GeneratedHttpRequest request) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUri(baseUri);
+        if (StringUtils.hasText(request.path())) {
+            builder.path(request.path());
+        }
+        MultiValueMap<String, String> queryParams = buildQueryParameters(request.queryParameters());
+        if (!queryParams.isEmpty()) {
+            builder.queryParams(queryParams);
+        }
+        return builder.build(true).toUri();
+    }
+
+    private MultiValueMap<String, String> buildQueryParameters(Map<String, Object> parameters) {
+        MultiValueMap<String, String> result = new LinkedMultiValueMap<>();
+        if (parameters == null) {
+            return result;
+        }
+        parameters.forEach((key, value) -> {
+            if (value == null) {
+                return;
+            }
+            if (value instanceof Iterable<?> iterable) {
+                for (Object item : iterable) {
+                    result.add(key, Objects.toString(item));
+                }
+            } else if (value.getClass().isArray()) {
+                int length = java.lang.reflect.Array.getLength(value);
+                for (int i = 0; i < length; i++) {
+                    Object item = java.lang.reflect.Array.get(value, i);
+                    result.add(key, Objects.toString(item));
+                }
+            } else {
+                result.add(key, Objects.toString(value));
+            }
+        });
+        return result;
+    }
+
+    private Map<String, String> flattenHeaders(HttpHeaders headers) {
+        if (headers == null) {
+            return Map.of();
+        }
+        Map<String, String> flattened = new HashMap<>();
+        headers.forEach((key, values) -> {
+            if (!values.isEmpty()) {
+                flattened.put(key, String.join(", ", values));
+            }
+        });
+        return flattened;
+    }
+
+    private boolean allowsBody(HttpMethod method) {
+        return switch (method) {
+            case GET, HEAD, OPTIONS, TRACE -> false;
+            default -> true;
+        };
+    }
+}

--- a/src/main/java/com/example/aifuzzy/llm/GeneratedHttpRequest.java
+++ b/src/main/java/com/example/aifuzzy/llm/GeneratedHttpRequest.java
@@ -1,0 +1,15 @@
+package com.example.aifuzzy.llm;
+
+import org.springframework.http.HttpMethod;
+
+import java.util.Map;
+
+public record GeneratedHttpRequest(
+        HttpMethod method,
+        String path,
+        Map<String, Object> queryParameters,
+        Map<String, String> headers,
+        String body,
+        String description
+) {
+}

--- a/src/main/java/com/example/aifuzzy/llm/LlmClient.java
+++ b/src/main/java/com/example/aifuzzy/llm/LlmClient.java
@@ -1,0 +1,8 @@
+package com.example.aifuzzy.llm;
+
+import java.util.List;
+
+public interface LlmClient {
+
+    List<GeneratedHttpRequest> generateRequests(String specification, int maxRequests);
+}

--- a/src/main/java/com/example/aifuzzy/llm/SimpleLlmClient.java
+++ b/src/main/java/com/example/aifuzzy/llm/SimpleLlmClient.java
@@ -1,0 +1,279 @@
+package com.example.aifuzzy.llm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Component
+public class SimpleLlmClient implements LlmClient {
+
+    private static final List<String> METHOD_ORDER = List.of("get", "post", "put", "delete", "patch");
+
+    private final ObjectMapper objectMapper;
+
+    public SimpleLlmClient(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<GeneratedHttpRequest> generateRequests(String specification, int maxRequests) {
+        if (!StringUtils.hasText(specification) || maxRequests <= 0) {
+            return List.of();
+        }
+
+        List<GeneratedHttpRequest> requests = new ArrayList<>();
+        try {
+            JsonNode root = objectMapper.readTree(specification);
+            JsonNode paths = root.path("paths");
+            if (!paths.isObject()) {
+                return fallback(specification, maxRequests);
+            }
+
+            Iterator<String> pathNames = paths.fieldNames();
+            while (pathNames.hasNext() && requests.size() < maxRequests) {
+                String pathKey = pathNames.next();
+                JsonNode pathNode = paths.path(pathKey);
+                List<JsonNode> pathParameters = readParameters(pathNode.path("parameters"));
+
+                for (String methodName : METHOD_ORDER) {
+                    if (requests.size() >= maxRequests) {
+                        break;
+                    }
+                    JsonNode methodNode = pathNode.path(methodName);
+                    if (!methodNode.isObject()) {
+                        continue;
+                    }
+                    List<JsonNode> methodParameters = readParameters(methodNode.path("parameters"));
+                    GeneratedHttpRequest request = buildRequest(pathKey, methodName, pathParameters, methodParameters, methodNode);
+                    if (request != null) {
+                        requests.add(request);
+                    }
+                }
+            }
+        } catch (JsonProcessingException exception) {
+            return fallback(specification, maxRequests);
+        }
+
+        if (requests.isEmpty()) {
+            return fallback(specification, maxRequests);
+        }
+        return requests;
+    }
+
+    private GeneratedHttpRequest buildRequest(String rawPath,
+                                              String methodName,
+                                              List<JsonNode> pathParameters,
+                                              List<JsonNode> methodParameters,
+                                              JsonNode methodNode) {
+        Map<String, Object> queryParameters = new LinkedHashMap<>();
+        Map<String, String> headerParameters = new LinkedHashMap<>();
+        Map<String, String> pathParameterValues = new LinkedHashMap<>();
+
+        List<JsonNode> allParameters = new ArrayList<>(pathParameters);
+        allParameters.addAll(methodParameters);
+        for (JsonNode parameterNode : allParameters) {
+            if (!parameterNode.isObject()) {
+                continue;
+            }
+            String location = parameterNode.path("in").asText();
+            String name = parameterNode.path("name").asText();
+            if (!StringUtils.hasText(location) || !StringUtils.hasText(name)) {
+                continue;
+            }
+            Object sample = sampleValue(parameterNode);
+            switch (location) {
+                case "query" -> {
+                    if (sample != null) {
+                        queryParameters.put(name, sample);
+                    }
+                }
+                case "header" -> {
+                    if (sample != null) {
+                        headerParameters.put(name, String.valueOf(sample));
+                    }
+                }
+                case "path" -> {
+                    String value = sample != null ? String.valueOf(sample) : name;
+                    pathParameterValues.put(name, value);
+                }
+                default -> {
+                    // ignore other locations for now
+                }
+            }
+        }
+
+        String resolvedPath = resolvePath(rawPath, pathParameterValues);
+        HttpMethod httpMethod = HttpMethod.resolve(methodName.toUpperCase(Locale.ROOT));
+        if (httpMethod == null) {
+            return null;
+        }
+        String description = methodNode.path("summary").asText(null);
+        if (!StringUtils.hasText(description)) {
+            description = methodNode.path("description").asText(null);
+        }
+        String body = extractRequestBody(methodNode.path("requestBody"));
+
+        return new GeneratedHttpRequest(httpMethod, resolvedPath, queryParameters, headerParameters, body, description);
+    }
+
+    private List<JsonNode> readParameters(JsonNode node) {
+        List<JsonNode> parameters = new ArrayList<>();
+        if (node.isArray()) {
+            node.forEach(parameters::add);
+        }
+        return parameters;
+    }
+
+    private Object sampleValue(JsonNode parameterNode) {
+        JsonNode candidate = firstNonNull(parameterNode.path("example"), parameterNode.path("default"));
+        JsonNode schema = parameterNode.path("schema");
+        if (schema.isObject()) {
+            candidate = firstNonNull(candidate, schema.path("example"), schema.path("default"));
+            if (!schema.path("type").isMissingNode() && (candidate == null || candidate.isMissingNode() || candidate.isNull())) {
+                return defaultByType(schema.path("type").asText());
+            }
+        }
+        if (candidate != null && !candidate.isMissingNode() && !candidate.isNull()) {
+            return convertNode(candidate);
+        }
+        if (schema.isObject()) {
+            return defaultByType(schema.path("type").asText(null));
+        }
+        return "sample";
+    }
+
+    private JsonNode firstNonNull(JsonNode... nodes) {
+        for (JsonNode node : nodes) {
+            if (node != null && !node.isMissingNode() && !node.isNull()) {
+                return node;
+            }
+        }
+        return null;
+    }
+
+    private Object convertNode(JsonNode node) {
+        if (node.isTextual()) {
+            return node.asText();
+        }
+        if (node.isNumber()) {
+            return node.numberValue();
+        }
+        if (node.isBoolean()) {
+            return node.booleanValue();
+        }
+        if (node.isArray()) {
+            return objectMapper.convertValue(node, new TypeReference<List<Object>>() { });
+        }
+        if (node.isObject()) {
+            return objectMapper.convertValue(node, new TypeReference<Map<String, Object>>() { });
+        }
+        return node.asText();
+    }
+
+    private Object defaultByType(String type) {
+        if (!StringUtils.hasText(type)) {
+            return "sample";
+        }
+        return switch (type) {
+            case "integer", "number" -> 1;
+            case "boolean" -> true;
+            default -> "sample";
+        };
+    }
+
+    private String resolvePath(String rawPath, Map<String, String> pathParameters) {
+        String resolved = rawPath;
+        if (!StringUtils.hasText(resolved)) {
+            resolved = "/";
+        }
+        for (Map.Entry<String, String> entry : pathParameters.entrySet()) {
+            String placeholder = "{" + entry.getKey() + "}";
+            String encoded = UriUtils.encodePathSegment(entry.getValue(), StandardCharsets.UTF_8);
+            resolved = resolved.replace(placeholder, encoded);
+        }
+        if (!resolved.startsWith("/")) {
+            resolved = "/" + resolved;
+        }
+        return resolved;
+    }
+
+    private String extractRequestBody(JsonNode requestBodyNode) {
+        if (!requestBodyNode.isObject()) {
+            return null;
+        }
+        JsonNode content = requestBodyNode.path("content");
+        if (!content.isObject()) {
+            return null;
+        }
+        JsonNode candidate = content.path("application/json");
+        if (!candidate.isObject()) {
+            Iterator<JsonNode> elements = content.elements();
+            if (elements.hasNext()) {
+                candidate = elements.next();
+            }
+        }
+        if (!candidate.isObject()) {
+            return null;
+        }
+        JsonNode example = firstNonNull(candidate.path("example"), extractExampleFromExamples(candidate.path("examples")));
+        if (example == null || example.isMissingNode() || example.isNull()) {
+            JsonNode schema = candidate.path("schema");
+            example = firstNonNull(schema.path("example"), schema.path("default"));
+        }
+        if (example == null || example.isMissingNode() || example.isNull()) {
+            return null;
+        }
+        if (example.isTextual()) {
+            return example.asText();
+        }
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(example);
+        } catch (JsonProcessingException e) {
+            return example.toString();
+        }
+    }
+
+    private JsonNode extractExampleFromExamples(JsonNode examplesNode) {
+        if (!examplesNode.isObject()) {
+            return null;
+        }
+        Iterator<JsonNode> iterator = examplesNode.elements();
+        while (iterator.hasNext()) {
+            JsonNode node = iterator.next();
+            JsonNode value = node.path("value");
+            if (!value.isMissingNode() && !value.isNull()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private List<GeneratedHttpRequest> fallback(String specification, int maxRequests) {
+        String snippet = specification.strip();
+        if (snippet.length() > 200) {
+            snippet = snippet.substring(0, 200) + "...";
+        }
+        GeneratedHttpRequest request = new GeneratedHttpRequest(
+                HttpMethod.GET,
+                "/",
+                Map.of(),
+                Map.of(),
+                null,
+                "Fallback request generated from specification snippet: " + snippet
+        );
+        return List.of(request);
+    }
+}

--- a/src/main/java/com/example/aifuzzy/repository/GeneratedRequestRepository.java
+++ b/src/main/java/com/example/aifuzzy/repository/GeneratedRequestRepository.java
@@ -1,0 +1,16 @@
+package com.example.aifuzzy.repository;
+
+import com.example.aifuzzy.domain.GeneratedRequestEntity;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface GeneratedRequestRepository extends JpaRepository<GeneratedRequestEntity, UUID> {
+
+    long countBySession_Id(UUID sessionId);
+
+    @EntityGraph(attributePaths = "executions")
+    List<GeneratedRequestEntity> findAllBySession_IdOrderByPathAsc(UUID sessionId);
+}

--- a/src/main/java/com/example/aifuzzy/repository/RequestExecutionRepository.java
+++ b/src/main/java/com/example/aifuzzy/repository/RequestExecutionRepository.java
@@ -1,0 +1,14 @@
+package com.example.aifuzzy.repository;
+
+import com.example.aifuzzy.domain.RequestExecutionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface RequestExecutionRepository extends JpaRepository<RequestExecutionEntity, UUID> {
+
+    long countByGeneratedRequest_Session_Id(UUID sessionId);
+
+    List<RequestExecutionEntity> findAllByGeneratedRequest_Session_Id(UUID sessionId);
+}

--- a/src/main/java/com/example/aifuzzy/repository/TestSessionRepository.java
+++ b/src/main/java/com/example/aifuzzy/repository/TestSessionRepository.java
@@ -1,0 +1,9 @@
+package com.example.aifuzzy.repository;
+
+import com.example.aifuzzy.domain.TestSessionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface TestSessionRepository extends JpaRepository<TestSessionEntity, UUID> {
+}

--- a/src/main/java/com/example/aifuzzy/service/TestSessionProcessor.java
+++ b/src/main/java/com/example/aifuzzy/service/TestSessionProcessor.java
@@ -1,0 +1,141 @@
+package com.example.aifuzzy.service;
+
+import com.example.aifuzzy.domain.GeneratedRequestEntity;
+import com.example.aifuzzy.domain.RequestExecutionEntity;
+import com.example.aifuzzy.domain.SessionStatus;
+import com.example.aifuzzy.domain.TestSessionEntity;
+import com.example.aifuzzy.http.HttpExecutionResult;
+import com.example.aifuzzy.http.HttpRequestExecutor;
+import com.example.aifuzzy.llm.GeneratedHttpRequest;
+import com.example.aifuzzy.llm.LlmClient;
+import com.example.aifuzzy.repository.GeneratedRequestRepository;
+import com.example.aifuzzy.repository.RequestExecutionRepository;
+import com.example.aifuzzy.repository.TestSessionRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class TestSessionProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestSessionProcessor.class);
+
+    private final TestSessionRepository sessionRepository;
+    private final GeneratedRequestRepository generatedRequestRepository;
+    private final RequestExecutionRepository executionRepository;
+    private final LlmClient llmClient;
+    private final HttpRequestExecutor httpRequestExecutor;
+    private final ObjectMapper objectMapper;
+
+    public TestSessionProcessor(TestSessionRepository sessionRepository,
+                                GeneratedRequestRepository generatedRequestRepository,
+                                RequestExecutionRepository executionRepository,
+                                LlmClient llmClient,
+                                HttpRequestExecutor httpRequestExecutor,
+                                ObjectMapper objectMapper) {
+        this.sessionRepository = sessionRepository;
+        this.generatedRequestRepository = generatedRequestRepository;
+        this.executionRepository = executionRepository;
+        this.llmClient = llmClient;
+        this.httpRequestExecutor = httpRequestExecutor;
+        this.objectMapper = objectMapper;
+    }
+
+    @Async
+    public void processSessionAsync(UUID sessionId, int maxRequests) {
+        Optional<TestSessionEntity> optional = sessionRepository.findById(sessionId);
+        if (optional.isEmpty()) {
+            LOGGER.warn("Cannot process session {} because it no longer exists", sessionId);
+            return;
+        }
+        TestSessionEntity session = optional.get();
+        try {
+            session.setStatus(SessionStatus.PROCESSING);
+            session.setUpdatedAt(Instant.now());
+            sessionRepository.save(session);
+
+            List<GeneratedHttpRequest> generatedRequests = llmClient.generateRequests(session.getSpecification(), maxRequests);
+            int limit = maxRequests > 0 ? Math.min(maxRequests, generatedRequests.size()) : generatedRequests.size();
+            URI baseUri = URI.create(session.getBaseUrl());
+
+            for (int i = 0; i < limit; i++) {
+                GeneratedHttpRequest generated = generatedRequests.get(i);
+                GeneratedRequestEntity requestEntity = createRequestEntity(session, generated);
+                generatedRequestRepository.save(requestEntity);
+
+                RequestExecutionEntity executionEntity = executeRequest(requestEntity, baseUri, generated);
+                executionRepository.save(executionEntity);
+            }
+
+            session.setStatus(SessionStatus.COMPLETED);
+            session.setUpdatedAt(Instant.now());
+            sessionRepository.save(session);
+        } catch (Exception exception) {
+            LOGGER.error("Failed to process session {}", sessionId, exception);
+            session.setStatus(SessionStatus.FAILED);
+            session.setFailureMessage(exception.getMessage());
+            session.setUpdatedAt(Instant.now());
+            sessionRepository.save(session);
+        }
+    }
+
+    private GeneratedRequestEntity createRequestEntity(TestSessionEntity session, GeneratedHttpRequest generated) {
+        GeneratedRequestEntity entity = new GeneratedRequestEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setSession(session);
+        entity.setHttpMethod(generated.method().name());
+        entity.setPath(generated.path());
+        entity.setQueryParameters(toJson(generated.queryParameters()));
+        entity.setHeaders(toJson(generated.headers()));
+        entity.setBody(generated.body());
+        entity.setDescription(generated.description());
+        return entity;
+    }
+
+    private RequestExecutionEntity executeRequest(GeneratedRequestEntity requestEntity, URI baseUri, GeneratedHttpRequest generated) {
+        RequestExecutionEntity execution = new RequestExecutionEntity();
+        execution.setId(UUID.randomUUID());
+        execution.setGeneratedRequest(requestEntity);
+        execution.setExecutedAt(Instant.now());
+        try {
+            HttpExecutionResult result = httpRequestExecutor.execute(baseUri, generated);
+            if (result.finalUrl() != null) {
+                execution.setFinalUrl(result.finalUrl().toString());
+            } else {
+                execution.setFinalUrl(baseUri.toString());
+            }
+            execution.setStatusCode(result.statusCode());
+            execution.setResponseBody(result.responseBody());
+            execution.setResponseHeaders(toJson(result.responseHeaders()));
+            execution.setLatencyMillis(result.latencyMillis());
+            execution.setErrorMessage(result.errorMessage());
+        } catch (Exception exception) {
+            LOGGER.warn("Failed to execute generated request {}", requestEntity.getId(), exception);
+            execution.setFinalUrl(baseUri.toString());
+            execution.setErrorMessage(exception.getMessage());
+        }
+        requestEntity.getExecutions().add(execution);
+        return execution;
+    }
+
+    private String toJson(Map<?, ?> value) {
+        if (value == null || value.isEmpty()) {
+            return "{}";
+        }
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialise map", e);
+        }
+    }
+}

--- a/src/main/java/com/example/aifuzzy/service/TestSessionService.java
+++ b/src/main/java/com/example/aifuzzy/service/TestSessionService.java
@@ -1,0 +1,209 @@
+package com.example.aifuzzy.service;
+
+import com.example.aifuzzy.domain.GeneratedRequestEntity;
+import com.example.aifuzzy.domain.RequestExecutionEntity;
+import com.example.aifuzzy.domain.SessionStatus;
+import com.example.aifuzzy.domain.TestSessionEntity;
+import com.example.aifuzzy.dto.RequestExecutionDto;
+import com.example.aifuzzy.dto.RequestResultDto;
+import com.example.aifuzzy.dto.TestSessionCreateRequestDto;
+import com.example.aifuzzy.dto.TestSessionResponseDto;
+import com.example.aifuzzy.dto.TestSessionSummaryDto;
+import com.example.aifuzzy.exception.ResourceNotFoundException;
+import com.example.aifuzzy.repository.GeneratedRequestRepository;
+import com.example.aifuzzy.repository.RequestExecutionRepository;
+import com.example.aifuzzy.repository.TestSessionRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+public class TestSessionService {
+
+    private static final int DEFAULT_MAX_REQUESTS = 10;
+
+    private final TestSessionRepository sessionRepository;
+    private final GeneratedRequestRepository generatedRequestRepository;
+    private final RequestExecutionRepository executionRepository;
+    private final TestSessionProcessor processor;
+    private final ObjectMapper objectMapper;
+
+    public TestSessionService(TestSessionRepository sessionRepository,
+                              GeneratedRequestRepository generatedRequestRepository,
+                              RequestExecutionRepository executionRepository,
+                              TestSessionProcessor processor,
+                              ObjectMapper objectMapper) {
+        this.sessionRepository = sessionRepository;
+        this.generatedRequestRepository = generatedRequestRepository;
+        this.executionRepository = executionRepository;
+        this.processor = processor;
+        this.objectMapper = objectMapper;
+    }
+
+    public TestSessionResponseDto createSession(TestSessionCreateRequestDto requestDto) {
+        URI baseUri = validateBaseUrl(requestDto.getBaseUrl());
+        String specification = requestDto.getSpecification();
+        if (!StringUtils.hasText(specification)) {
+            throw new IllegalArgumentException("Specification must not be blank");
+        }
+        int maxRequests = requestDto.getMaxRequests() != null ? requestDto.getMaxRequests() : DEFAULT_MAX_REQUESTS;
+
+        TestSessionEntity session = new TestSessionEntity();
+        session.setId(UUID.randomUUID());
+        session.setBaseUrl(baseUri.toString());
+        session.setSpecification(specification);
+        session.setStatus(SessionStatus.PROCESSING);
+        session.setCreatedAt(Instant.now());
+        session.setUpdatedAt(Instant.now());
+        session.setMaxRequests(maxRequests);
+        sessionRepository.save(session);
+
+        processor.processSessionAsync(session.getId(), maxRequests);
+        return new TestSessionResponseDto(session.getId(), session.getStatus());
+    }
+
+    @Transactional(readOnly = true)
+    public TestSessionSummaryDto getSessionSummary(UUID sessionId) {
+        TestSessionEntity session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new ResourceNotFoundException("Session not found: " + sessionId));
+
+        long generatedCount = generatedRequestRepository.countBySession_Id(sessionId);
+        List<RequestExecutionEntity> executions = executionRepository.findAllByGeneratedRequest_Session_Id(sessionId);
+        long executedCount = executions.size();
+        long successCount = executions.stream()
+                .filter(execution -> execution.getStatusCode() != null
+                        && execution.getStatusCode() >= 200
+                        && execution.getStatusCode() < 400
+                        && !StringUtils.hasText(execution.getErrorMessage()))
+                .count();
+        long failureCount = executedCount - successCount;
+        double successRate = executedCount == 0 ? 0.0 : (double) successCount / executedCount;
+        Long averageLatency = executions.stream()
+                .map(RequestExecutionEntity::getLatencyMillis)
+                .filter(Objects::nonNull)
+                .mapToLong(Long::longValue)
+                .average()
+                .stream()
+                .mapToLong(value -> Math.round(value))
+                .boxed()
+                .findFirst()
+                .orElse(null);
+
+        Map<Integer, Long> histogram = executions.stream()
+                .filter(execution -> execution.getStatusCode() != null)
+                .collect(Collectors.groupingBy(RequestExecutionEntity::getStatusCode, TreeMap::new, Collectors.counting()));
+
+        return new TestSessionSummaryDto(
+                session.getId(),
+                session.getStatus(),
+                (int) generatedCount,
+                (int) executedCount,
+                (int) successCount,
+                (int) failureCount,
+                successRate,
+                averageLatency,
+                histogram,
+                session.getCreatedAt(),
+                session.getUpdatedAt(),
+                session.getFailureMessage()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<RequestResultDto> getSessionResults(UUID sessionId) {
+        if (!sessionRepository.existsById(sessionId)) {
+            throw new ResourceNotFoundException("Session not found: " + sessionId);
+        }
+        List<GeneratedRequestEntity> requests = generatedRequestRepository.findAllBySession_IdOrderByPathAsc(sessionId);
+        return requests.stream()
+                .map(this::toRequestResultDto)
+                .toList();
+    }
+
+    private RequestResultDto toRequestResultDto(GeneratedRequestEntity entity) {
+        Map<String, Object> queryParameters = readObjectMap(entity.getQueryParameters());
+        Map<String, String> headers = readStringMap(entity.getHeaders());
+        List<RequestExecutionDto> executions = entity.getExecutions().stream()
+                .sorted(Comparator.comparing(RequestExecutionEntity::getExecutedAt))
+                .map(this::toExecutionDto)
+                .toList();
+        return new RequestResultDto(
+                entity.getId(),
+                entity.getHttpMethod(),
+                entity.getPath(),
+                queryParameters,
+                headers,
+                entity.getBody(),
+                entity.getDescription(),
+                executions
+        );
+    }
+
+    private RequestExecutionDto toExecutionDto(RequestExecutionEntity execution) {
+        Map<String, String> responseHeaders = readStringMap(execution.getResponseHeaders());
+        return new RequestExecutionDto(
+                execution.getId(),
+                execution.getFinalUrl(),
+                execution.getExecutedAt(),
+                execution.getStatusCode(),
+                execution.getLatencyMillis(),
+                responseHeaders,
+                execution.getResponseBody(),
+                execution.getErrorMessage()
+        );
+    }
+
+    private Map<String, Object> readObjectMap(String json) {
+        if (!StringUtils.hasText(json) || "{}".equals(json)) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<Map<String, Object>>() { });
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to parse stored JSON", e);
+        }
+    }
+
+    private Map<String, String> readStringMap(String json) {
+        if (!StringUtils.hasText(json) || "{}".equals(json)) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<Map<String, String>>() { });
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to parse stored JSON", e);
+        }
+    }
+
+    private URI validateBaseUrl(String baseUrl) {
+        if (!StringUtils.hasText(baseUrl)) {
+            throw new IllegalArgumentException("Base URL must not be blank");
+        }
+        URI uri;
+        try {
+            uri = URI.create(baseUrl);
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException("Base URL is not a valid URI", exception);
+        }
+        if (!StringUtils.hasText(uri.getScheme())) {
+            throw new IllegalArgumentException("Base URL must contain scheme");
+        }
+        if (!StringUtils.hasText(uri.getHost()) && uri.getAuthority() == null) {
+            throw new IllegalArgumentException("Base URL must contain host");
+        }
+        return uri;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:aifuzzy;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+  h2:
+    console:
+      enabled: true
+
+logging:
+  level:
+    org.springframework.jdbc.core.JdbcTemplate: WARN
+    org.hibernate.SQL: WARN

--- a/src/test/java/com/example/aifuzzy/service/TestSessionServiceIntegrationTest.java
+++ b/src/test/java/com/example/aifuzzy/service/TestSessionServiceIntegrationTest.java
@@ -1,0 +1,124 @@
+package com.example.aifuzzy.service;
+
+import com.example.aifuzzy.domain.SessionStatus;
+import com.example.aifuzzy.dto.RequestExecutionDto;
+import com.example.aifuzzy.dto.RequestResultDto;
+import com.example.aifuzzy.dto.TestSessionCreateRequestDto;
+import com.example.aifuzzy.dto.TestSessionResponseDto;
+import com.example.aifuzzy.dto.TestSessionSummaryDto;
+import com.example.aifuzzy.http.HttpExecutionResult;
+import com.example.aifuzzy.http.HttpRequestExecutor;
+import com.example.aifuzzy.llm.GeneratedHttpRequest;
+import com.example.aifuzzy.llm.LlmClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.TestConfiguration;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class TestSessionServiceIntegrationTest {
+
+    private final TestSessionService service;
+
+    TestSessionServiceIntegrationTest(TestSessionService service) {
+        this.service = service;
+    }
+
+    @Test
+    void createsSessionProcessesRequestsAndBuildsStatistics() {
+        TestSessionCreateRequestDto request = new TestSessionCreateRequestDto();
+        request.setBaseUrl("https://api.example.com");
+        request.setSpecification("{\"paths\":{\"/hello\":{\"get\":{\"summary\":\"Hello\"}}}}");
+        request.setMaxRequests(5);
+
+        TestSessionResponseDto response = service.createSession(request);
+
+        TestSessionSummaryDto summary = service.getSessionSummary(response.sessionId());
+        assertThat(summary.status()).isEqualTo(SessionStatus.COMPLETED);
+        assertThat(summary.generatedRequests()).isEqualTo(2);
+        assertThat(summary.executedRequests()).isEqualTo(2);
+        assertThat(summary.successCount()).isEqualTo(1);
+        assertThat(summary.failureCount()).isEqualTo(1);
+        assertThat(summary.successRate()).isGreaterThan(0.0);
+        assertThat(summary.averageLatencyMillis()).isNotNull();
+        assertThat(summary.statusCodeHistogram()).containsEntry(200, 1L).containsEntry(500, 1L);
+
+        List<RequestResultDto> results = service.getSessionResults(response.sessionId());
+        assertThat(results).hasSize(2);
+
+        RequestResultDto first = results.get(0);
+        assertThat(first.method()).isEqualTo("GET");
+        assertThat(first.executions()).hasSize(1);
+        RequestExecutionDto firstExecution = first.executions().get(0);
+        assertThat(firstExecution.statusCode()).isEqualTo(200);
+        assertThat(firstExecution.finalUrl()).isEqualTo("https://api.example.com/hello");
+        assertThat(firstExecution.responseBody()).contains("ok");
+
+        RequestResultDto second = results.get(1);
+        assertThat(second.method()).isEqualTo("POST");
+        assertThat(second.executions()).hasSize(1);
+        RequestExecutionDto secondExecution = second.executions().get(0);
+        assertThat(secondExecution.statusCode()).isEqualTo(500);
+        assertThat(secondExecution.errorMessage()).isEqualTo("Internal error");
+    }
+
+    @TestConfiguration
+    static class TestBeans {
+
+        @Bean
+        public TaskExecutor taskExecutor() {
+            return new SyncTaskExecutor();
+        }
+
+        @Bean
+        @Primary
+        public LlmClient llmClient() {
+            return new StubLlmClient();
+        }
+
+        @Bean
+        @Primary
+        public HttpRequestExecutor httpRequestExecutor() {
+            return new StubHttpRequestExecutor();
+        }
+    }
+
+    private static class StubLlmClient implements LlmClient {
+
+        @Override
+        public List<GeneratedHttpRequest> generateRequests(String specification, int maxRequests) {
+            return List.of(
+                    new GeneratedHttpRequest(HttpMethod.GET, "/hello", Map.of(), Map.of(), null, "get hello"),
+                    new GeneratedHttpRequest(HttpMethod.POST, "/items", Map.of(), Map.of("X-Test", "value"), "{\"name\":\"item\"}", "create item")
+            );
+        }
+    }
+
+    private static class StubHttpRequestExecutor implements HttpRequestExecutor {
+
+        @Override
+        public HttpExecutionResult execute(URI baseUri, GeneratedHttpRequest request) {
+            URI target = UriComponentsBuilder.fromUri(baseUri)
+                    .path(request.path())
+                    .build(true)
+                    .toUri();
+            if (request.method() == HttpMethod.POST) {
+                return new HttpExecutionResult(target, 500, "{\"error\":true}", Map.of(), 12L, "Internal error");
+            }
+            return new HttpExecutionResult(target, 200, "{\"status\":\"ok\"}", Map.of("Content-Type", "application/json"), 5L, null);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- stop mutating TestSessionEntity.generatedRequests inside the async processor to avoid lazy initialization when the session entity is detached

## Testing
- `mvn test` *(fails: unable to resolve Spring Boot parent POM because the environment blocks outbound network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cffdc362a0832abf7d26c9b60da33a