### PR TITLE
Rewrite allowsBody using classic control flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>aifuzzy</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>AiFuzzy</name>
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+</project>

--- a/src/main/java/com/example/aifuzzy/http/HttpMethod.java
+++ b/src/main/java/com/example/aifuzzy/http/HttpMethod.java
@@ -1,0 +1,15 @@
+package com.example.aifuzzy.http;
+
+/**
+ * Simplified HTTP method enumeration used by {@link WebClientHttpRequestExecutor}.
+ */
+public enum HttpMethod {
+    GET,
+    HEAD,
+    POST,
+    PUT,
+    PATCH,
+    DELETE,
+    OPTIONS,
+    TRACE
+}

--- a/src/main/java/com/example/aifuzzy/http/WebClientHttpRequestExecutor.java
+++ b/src/main/java/com/example/aifuzzy/http/WebClientHttpRequestExecutor.java
@@ -1,0 +1,32 @@
+package com.example.aifuzzy.http;
+
+/**
+ * Executes HTTP requests using a web client. The executor decides whether a
+ * particular HTTP method supports a request body via {@link #allowsBody(HttpMethod)}.
+ */
+public class WebClientHttpRequestExecutor {
+
+    /**
+     * Determine if a request body is allowed for the supplied HTTP method.
+     *
+     * @param method HTTP method to check.
+     * @return {@code true} when a request body is allowed, {@code false} otherwise.
+     */
+    public boolean allowsBody(HttpMethod method) {
+        if (method == null) {
+            return false;
+        }
+
+        if (method == HttpMethod.GET) {
+            return false;
+        } else if (method == HttpMethod.HEAD) {
+            return false;
+        } else if (method == HttpMethod.OPTIONS) {
+            return false;
+        } else if (method == HttpMethod.TRACE) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a minimal Maven POM so the project can be compiled locally
- introduce a lightweight HttpMethod enum for the HTTP executor
- rewrite allowsBody to use classic if/else logic returning false for GET/HEAD/OPTIONS/TRACE

## Testing
- mvn -o compile

------
https://chatgpt.com/codex/tasks/task_e_68d1304e5844832a8581f102d0881394