### PR TITLE
Update HTTP method resolution for Spring 6 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>aifuzzy</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>AiFuzzy</name>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>6.1.6</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/com/example/aifuzzy/llm/SimpleLlmClient.java
+++ b/src/main/java/com/example/aifuzzy/llm/SimpleLlmClient.java
@@ -1,0 +1,40 @@
+package com.example.aifuzzy.llm;
+
+import java.util.Locale;
+
+import org.springframework.http.HttpMethod;
+
+/**
+ * Simple client stub used to demonstrate HTTP method resolution.
+ */
+public class SimpleLlmClient {
+
+    /**
+     * Resolve an HTTP method name to a {@link HttpMethod} instance.
+     * <p>
+     * In Spring 6 the {@code HttpMethod.resolve} helper was removed, so we
+     * reproduce the previous behaviour by normalising the input and catching
+     * the {@link IllegalArgumentException} thrown by {@link HttpMethod#valueOf(String)}.
+     * </p>
+     *
+     * @param methodName raw HTTP method name
+     * @return the resolved {@code HttpMethod} or {@code null} when the method is not supported
+     */
+    protected HttpMethod resolveHttpMethod(String methodName) {
+        if (methodName == null) {
+            return null;
+        }
+
+        String normalized = methodName.trim();
+        if (normalized.isEmpty()) {
+            return null;
+        }
+
+        normalized = normalized.toUpperCase(Locale.ROOT);
+        try {
+            return HttpMethod.valueOf(normalized);
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Maven build descriptor for the project
- update the `SimpleLlmClient` HTTP method resolution to use `HttpMethod.valueOf` with graceful fallback when the method is unsupported

## Testing
- `mvn compile` *(fails: unable to download Maven plugin because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1304f89c8832a96d0ed5999776c4c